### PR TITLE
Add files via upload

### DIFF
--- a/modules/lowvram.py
+++ b/modules/lowvram.py
@@ -1,8 +1,39 @@
 import torch
 from modules import devices
+## if you want to reduce memory requirements, use model simplification, quantization, gradient checkpointing, mixed precision training, or working with smaller batch sizes
 
 module_in_gpu = None
 cpu = torch.device("cpu")
+# Set the GPU memory threshold in bytes
+threshold = 0.80 * torch.cuda.get_device_properties(0).total_memory  # 80% of total GPU memory, provides a 20% buffer
+# Perform GPU computations
+tensor_gpu = torch.randn(10, 3, 1600, 1600, device='cuda')
+#10 = batch_size = number of images being processed // may need to refine this. 
+#3 = RGB colors used by MOST models minus scientific ones which may have more data - but this should be kept as '3'
+#width - the width of the  images
+#height = the height of the image.
+## This is a basic memory check and won't handle spikes during training
+
+def check_memory_and_allocate(shape):
+    # Get current memory usage
+    current_memory = torch.cuda.memory_allocated()
+    # Get total GPU memory
+    total_memory = torch.cuda.get_device_properties(0).total_memory
+    # Calculate the size of the new tensor
+    new_tensor_memory = torch.Tensor(*shape).numel() * 4  # 4 bytes per float32
+    # Check if there is enough memory left for the new tensor
+    if current_memory + new_tensor_memory > total_memory * 0.9:  # leave 10% buffer
+        print("Insufficient memory to create new tensor. Reducing batch size or model size might be necessary.")
+        #return torch.randn(*shape, device='cuda') #can uncomment if you want to use CPU when getting warning
+    else:
+        return torch.randn(*shape, device='cuda')
+
+if torch.cuda.memory_allocated() > threshold:
+    print("Switching to CPU...")
+    tensor_cpu = tensor_gpu.to('cpu')
+else:
+    print("Continuing with GPU computations...")
+    result_gpu = tensor_gpu * 2
 
 
 def send_everything_to_cpu():
@@ -22,9 +53,14 @@ def setup_for_low_vram(sd_model, use_medvram):
         we add this as forward_pre_hook to a lot of modules and this way all but one of them will
         be in CPU
         """
-        global module_in_gpu
-
-        module = parents.get(module, module)
+        global module_in_gpu  
+        # Monitor GPU memory usage and switch to CPU if threshold is exceeded
+        threshold = torch.cuda.max_memory_allocated() *0.85 #15% buffer - not to be used when training models
+        if threshold > 0:
+            if torch.cuda.memory_allocated() > threshold:
+                print("Switching to CPU...")
+                send_everything_to_cpu()
+                module = parents.get(module, module)
 
         if module_in_gpu == module:
             return
@@ -44,11 +80,11 @@ def setup_for_low_vram(sd_model, use_medvram):
     first_stage_model_decode = sd_model.first_stage_model.decode
 
     def first_stage_model_encode_wrap(x):
-        send_me_to_gpu(first_stage_model, None)
+        send_me_to_gpu(first_stage_model, None)       
         return first_stage_model_encode(x)
 
     def first_stage_model_decode_wrap(z):
-        send_me_to_gpu(first_stage_model, None)
+        send_me_to_gpu(first_stage_model, None)          
         return first_stage_model_decode(z)
 
     # for SD1, cond_stage_model is CLIP and its NN is in the tranformer frield, but for SD2, it's open clip, and it's in model field
@@ -79,6 +115,9 @@ def setup_for_low_vram(sd_model, use_medvram):
 
     if use_medvram:
         sd_model.model.register_forward_pre_hook(send_me_to_gpu)
+        if torch.cuda.memory_allocated() > threshold:
+            print("Switching to CPU...")
+            send_everything_to_cpu()
     else:
         diff_model = sd_model.model.diffusion_model
 
@@ -96,3 +135,8 @@ def setup_for_low_vram(sd_model, use_medvram):
         diff_model.middle_block.register_forward_pre_hook(send_me_to_gpu)
         for block in diff_model.output_blocks:
             block.register_forward_pre_hook(send_me_to_gpu)
+        # Monitor GPU memory usage and switch to CPU if threshold is exceeded
+            if torch.cuda.memory_allocated() > threshold:
+                print("Switching to CPU...")
+                send_everything_to_cpu()
+


### PR DESCRIPTION

![00003-2023-05-18](https://github.com/unicornsyay/stable-diffusion-webui/assets/30913640/b5fa7702-56dc-4025-bf26-5742df16015b)
[00002-2023-05-18.txt](https://github.com/unicornsyay/stable-diffusion-webui/files/11511599/00002-2023-05-18.txt)
![00002-2023-05-18](https://github.com/unicornsyay/stable-diffusion-webui/assets/30913640/96ca40f7-d4ba-444c-b6be-b3c70bd8bf84)
[00001-2023-05-18.txt](https://github.com/unicornsyay/stable-diffusion-webui/files/11511600/00001-2023-05-18.txt)
![00001-2023-05-18](https://github.com/unicornsyay/stable-diffusion-webui/assets/30913640/b9fb1edc-d0b8-4f9f-86af-f12a3a15f8fc)
[00003-2023-05-18.txt](https://github.com/unicornsyay/stable-diffusion-webui/files/11511601/00003-2023-05-18.txt)
Adds Memory Checks and if using --lowvram or --medvram will process with CPU if you have low VRAM.  Adds "threshold" which you can edit to set the videoram threshold for when you switch from video to CPU.  Performs a basic memory check for torch. 
Note: not to be used when training models, because it is really slow!

# Please read the [contributing wiki page](https://github.com/AUTOMATIC1111/stable-diffusion-webui/wiki/Contributing) before submitting a pull request!

If you have a large change, pay special attention to this paragraph:

> Before making changes, if you think that your feature will result in more than 100 lines changing, find me and talk to me about the feature you are proposing. It pains me to reject the hard work someone else did, but I won't add everything to the repo, and it's better if the rejection happens before you have to waste time working on the feature.

Otherwise, after making sure you're following the rules
![10 steps at 1800 X 1800 = cuda error](https://github.com/unicornsyay/stable-diffusion-webui/assets/30913640/df580147-d12a-49a7-b9e8-2f4960078740)
![20 steps at 900 X 900](https://github.com/unicornsyay/stable-diffusion-webui/assets/30913640/ca6a2323-2e97-4b20-8ca6-37a3a0075ddc)
![50 steps at 1500x1500](https://github.com/unicornsyay/stable-diffusion-webui/assets/30913640/68b51c23-81a8-4225-a033-c9ab40ab7ca1)
 described in wiki page, remove this section and continue on.

**Describe what this pull request is trying to achieve.**
To automatically detect and transfer from GPU to CPU when you run low on memory. While it is slower, and not recommended for training a model, it can better assist if running low on memory. It can help avoid some out of memory.
Creates a "threshold" with a buffer so that if you aren't using it to train but just creating a few images, then it will send your tensors to the CPU instead of continuing to use VRAM. 


**Additional notes and description of your changes**

tensor_gpu variable was not set to variables but to numbers. A module which defined width, height, and batch_size would be able to automate this. Presently the shape is set to a batch size of 10, and 1600X 1600 for the resolution. This variable is only to perform a rudimentary memory check and will get a warning if you are exceeding a memory point. I set that memory point at 10% buffer, or .90 of total memory. 

**Environment this was tested in**
Windows 11 Pro-64bit (10.0, Build 22000)
Processor: 12th Gen Intel(R) Core (TM) i9-12900KF (24 CPUs), ~ 3.2GHz
Memory: 65536MB RAM
Page File: 16322MB Used, 58781MB available
DirectX Version: DirextX 12
Browser: Chrome and Opera
Graphics Card: NVidia GeForce RTX 3080 Ti, Memory RAM: 12100 MB, Shared Memory: 32688 MB, Driver Model WDDM 3.0
- DirectDraw Acceleration: Enabled
- Direct3D Acceleration: Enabled
- AGP Texture Acceleration: Enabled
- DirectX 12 Ultimate: Enabled

List the environment you have developed / tested this on. As per the contributing page, changes should be able to work on Windows out of the box.
 - OS: [e.g. Windows, Linux]
 - Browser: [e.g. chrome, safari]
 - Graphics card: [e.g. NVIDIA RTX 2080 8GB, AMD RX 6600 8GB]

**Screenshots or videos of your changes**

If applicable, screenshots or a video showing off your changes. If it edits an existing UI, it should ideally contain a comparison of what used to be there, before your changes were made.

This is **required** for anything that touches the user interface.